### PR TITLE
Pin chatterbox-tts version to 0.1.2 in requirements.txt

### DIFF
--- a/chatterbox-tts/requirements.txt
+++ b/chatterbox-tts/requirements.txt
@@ -1,3 +1,3 @@
-chatterbox-tts
+chatterbox-tts==0.1.2
 litserve
 requests


### PR DESCRIPTION
## What does this PR do?

Pin chatterbox-tts version to 0.1.2 in requirements.txt

**Related Issue:**
Fixes #8

**Additional Notes:**

It seems that the latest releases may have some package issues, so the version has been pinned to a more stable one.